### PR TITLE
Search filter model performance improvement

### DIFF
--- a/src/models/AuditEntrySearch.php
+++ b/src/models/AuditEntrySearch.php
@@ -41,6 +41,7 @@ class AuditEntrySearch extends AuditEntry
     public function search($params)
     {
         $query = AuditEntry::find();
+        $query->select($this->safeAttributes());
 
         $dataProvider = new ActiveDataProvider([
             'query' => $query,

--- a/src/models/AuditErrorSearch.php
+++ b/src/models/AuditErrorSearch.php
@@ -42,6 +42,7 @@ class AuditErrorSearch extends AuditError
     public function search($params)
     {
         $query = AuditError::find();
+        $query->select($this->safeAttributes());
 
         $dataProvider = new ActiveDataProvider([
             'query' => $query,

--- a/src/models/AuditJavascriptSearch.php
+++ b/src/models/AuditJavascriptSearch.php
@@ -39,6 +39,7 @@ class AuditJavascriptSearch extends AuditJavascript
     public function search($params)
     {
         $query = AuditJavascript::find();
+        $query->select($this->safeAttributes());
 
         $dataProvider = new ActiveDataProvider([
             'query' => $query,

--- a/src/models/AuditMailSearch.php
+++ b/src/models/AuditMailSearch.php
@@ -39,6 +39,7 @@ class AuditMailSearch extends AuditMail
     public function search($params)
     {
         $query = AuditMail::find();
+        $query->select($this->safeAttributes());
 
         $dataProvider = new ActiveDataProvider([
             'query' => $query,

--- a/src/models/AuditTrailSearch.php
+++ b/src/models/AuditTrailSearch.php
@@ -41,6 +41,7 @@ class AuditTrailSearch extends AuditTrail
     public function search($params, $query = null)
     {
         $query = $query ? $query : $this->find();
+        $query->select($this->safeAttributes());
 
         $dataProvider = new ActiveDataProvider([
             'query' => $query,


### PR DESCRIPTION
Add only the safe attributes in select to exclude data columns like `data`, `html` or similar. In the case of this search models we can do this because there are no custom properties.